### PR TITLE
Patch to convert EDS to shares

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,3 +65,5 @@ require (
 	google.golang.org/grpc v1.40.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 )
+
+replace github.com/ipfs/go-verifcid => github.com/lazyledger/go-verifcid v0.0.1-lazypatch

--- a/ipld/write.go
+++ b/ipld/write.go
@@ -3,6 +3,8 @@ package ipld
 import (
 	"context"
 	"fmt"
+	"math"
+
 	"github.com/celestiaorg/nmt"
 	"github.com/celestiaorg/rsmt2d"
 	ipld "github.com/ipfs/go-ipld-format"
@@ -11,22 +13,35 @@ import (
 )
 
 // PutData posts erasured block data to IPFS using the provided ipld.NodeAdder.
-func PutData(ctx context.Context, eds *rsmt2d.ExtendedDataSquare, adder ipld.NodeAdder) (*rsmt2d.ExtendedDataSquare, error) {
+func PutData(ctx context.Context, shares [][]byte, adder ipld.NodeAdder) (*rsmt2d.ExtendedDataSquare, error) {
+	if len(shares) == 0 {
+		return nil, fmt.Errorf("empty data") // empty block is not an empty Data
+	}
 	// create nmt adder wrapping batch adder
 	batchAdder := NewNmtNodeAdder(ctx, ipld.NewBatch(ctx, adder))
 	// create the nmt wrapper to generate row and col commitments
-	tree := wrapper.NewErasuredNamespacedMerkleTree(uint64(eds.Width()), nmt.NodeVisitor(batchAdder.Visit))
-	// recompute the eds // TODO @renaynay: is this right?
-	shares := make([][]byte, 0)
-	for i := 0; i < int(eds.Width()/2); i++ {
-		shares = append(shares, eds.Row(uint(i))...)
-	}
-	recomputed, err := rsmt2d.ComputeExtendedDataSquare(shares, rsmt2d.NewRSGF8Codec(), tree.Constructor)
+	squareSize := uint32(math.Sqrt(float64(len(shares))))
+	fmt.Println("square size when put data", squareSize)
+	tree := wrapper.NewErasuredNamespacedMerkleTree(uint64(squareSize), nmt.NodeVisitor(batchAdder.Visit))
+	// recompute the eds
+	eds, err := rsmt2d.ComputeExtendedDataSquare(shares, rsmt2d.NewRSGF8Codec(), tree.Constructor)
 	if err != nil {
 		return nil, fmt.Errorf("failure to recompute the extended data square: %w", err)
 	}
 	// compute roots
-	recomputed.ColRoots()
+	eds.RowRoots()
 	// commit the batch to ipfs
 	return eds, batchAdder.Commit()
+}
+
+func convertEDStoShares(eds *rsmt2d.ExtendedDataSquare) [][]byte {
+	origWidth := eds.Width() / 2
+	origShares := make([][]byte, origWidth*origWidth)
+	for i := uint(0); i < origWidth; i++ {
+		row := eds.Row(i)
+		for j := uint(0); j < origWidth; j++ {
+			origShares[(i*origWidth)+j] = row[j]
+		}
+	}
+	return origShares
 }


### PR DESCRIPTION
This PR adds a helper func to convert extended data squares to original raw shares, along with slightly modifying one of the test utility functions that generates test data.

please feel free to rename anything.